### PR TITLE
Add camelcase conversion to tableName in mergeNested.ts

### DIFF
--- a/src/genSchema/mergeNested.ts
+++ b/src/genSchema/mergeNested.ts
@@ -1,8 +1,9 @@
 import { generateZodSchemaCode } from './generateZodSchemaCode.js'
 import { getDetailsFromDefinition } from './getDetailsFromDefinition.js'
+import {toCamelCase} from "../helper/toCamelCase.js";
 
 export const mergeNested = (fields: Record<string, string>, isInputSchema: boolean, tableName: string) => {
-	const schemaName = `${tableName}${isInputSchema ? 'Input' : 'Output'}SchemaGen`
+	const schemaName = `${toCamelCase(tableName)}${isInputSchema ? 'Input' : 'Output'}SchemaGen`
 
 	const inputFields = Object.entries(fields)
 		.map(([_fname, definition]) => {


### PR DESCRIPTION
Camelcase conversion was missing in the merge nested function leading to incorrect naming:

```ts
//_generated/belongsTo/belongsToSchemaGen.ts
export const belongs_toInputSchemaGen = z.object({}).passthrough();

//schema/belongsTo/belongsToSchema.ts
import { belongsToInputSchemaGen, belongsToOutputSchemaGen } from "../../_generated/belongsTo/belongsToSchemaGen.js";
```
