### PR TITLE
Reorder flexible and passthrough

### DIFF
--- a/src/genSchema/getDetailsFromDefinition.ts
+++ b/src/genSchema/getDetailsFromDefinition.ts
@@ -78,10 +78,12 @@ export const getZodTypeFromQLType = (tokens: TokenizedDefinition, isInputSchema:
 		if (tokens.assert) {
 			schema = handleAssertions(schema, tokens.assert, type)
 		}
-		schema = makeOptional(schema, tokens, isInputSchema)
+
 		if (type === 'object') {
 			schema = makeFlexible(schema, !!tokens.flexible)
 		}
+		schema = makeOptional(schema, tokens, isInputSchema)
+
 		return schema
 	}
 	return 'z.unknown()'


### PR DESCRIPTION
optional should come after passthrough in zod definition
`z.object({}).optional().passthrough()` -> `z.object({}).passthrough().optional()`