### PR TITLE
Fix generic

### DIFF
--- a/src/genSchema/ensureRecordSchema.ts
+++ b/src/genSchema/ensureRecordSchema.ts
@@ -9,7 +9,7 @@ import { RecordId } from 'surrealdb.js'
 export const ZRecordIdInstanceOf = z.instanceof(RecordId);
 
 export function recordId<Table extends string = string>(table?: Table) {
-  return z.custom<RecordId<\`$Table\`>>(
+  return z.custom<RecordId<Table>>(
     val => {
       const instanceOfCheck = ZRecordIdInstanceOf.safeParse(val);
       const tableCheck = table ? val?.tb === table : true;


### PR DESCRIPTION
The string literal used for creating the recordId zod type had ```return z.custom<RecordId<\`$Table \`>>```  which was causing all records to expect the table value `$Table`; this seems to be an issue with Zod's type inference. Changed to `<Table>` to pass the generic correctly