### PR TITLE
rename `surrealdb.js` to `surrealdb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 ## 🚨 Warning Version 2.x
 
 Version 2 has breaking changes!  
-The tool now uses `surrealdb.js` instead of `surrealdb.node` for interacting with a SurrealDB instance.
+The tool now uses `surrealdb` instead of `surrealdb.node` for interacting with a SurrealDB instance.
 
-The change was made, because it seems that `surrealdb.js` is closer to the SurrealDB development process and more up to date in general.
+The change was made, because it seems that `surrealdb` is closer to the SurrealDB development process and more up to date in general.
 
 This means, the option "memory" for connections is no longer available, and you need to run against a real running SurrealDB instance (use docker).
 
@@ -95,7 +95,7 @@ Example:
   "db": "my_database",
   "outputFolder": "./out",
   "generateClient": true,
-  "lib": "surrealdb.js"
+  "lib": "surrealdb"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"commander": "^12.1.0",
 		"mkdirp": "^3.0.1",
 		"rimraf": "^6.0.0",
-		"surrealdb.js": "^1.0.0-beta.9",
+		"surrealdb": "^1.0.0-beta.19",
 		"zod": "^3.23.8"
 	},
 	"tshy": {

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,4 +1,4 @@
-import { Surreal } from 'surrealdb.js'
+import { Surreal } from 'surrealdb'
 
 import type { Config } from '../config/types.js'
 

--- a/src/genSchema/ensureRecordSchema.test.ts
+++ b/src/genSchema/ensureRecordSchema.test.ts
@@ -1,4 +1,4 @@
-import { RecordId, StringRecordId } from 'surrealdb.js'
+import { RecordId, StringRecordId } from 'surrealdb'
 import { describe, expect, test } from 'vitest'
 import z from 'zod'
 

--- a/src/genSchema/ensureRecordSchema.ts
+++ b/src/genSchema/ensureRecordSchema.ts
@@ -4,7 +4,7 @@ import { mkdirp } from 'mkdirp'
 
 export const ensureRecordSchema = async (rootPath: string) => {
 	const content = `import z from 'zod';
-import { RecordId, StringRecordId } from 'surrealdb.js'
+import { RecordId, StringRecordId } from 'surrealdb'
 
 type TableRecordId<T extends string> = RecordId<T> | StringRecordId | \`\${T}:\${string}\`;
 

--- a/src/genSchema/generateTableSchema.ts
+++ b/src/genSchema/generateTableSchema.ts
@@ -127,7 +127,7 @@ export const ${tableName}Schema = ${tableName}OutputSchemaGen.merge(z.object({
 				const typeFileContent = `/* Place your custom changes here */
 
 import { z } from "zod";
-import { type RecordId} from "surrealdb.js";
+import { type RecordId} from "surrealdb";
 
 import { ${tableName}CreateSchema, ${tableName}Schema } from "./${tableName}Schema.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ const main = async () => {
 		await generateTableSchema(resolve(__dirname, config.outputFolder), tableInfo)
 
 		if (config.generateClient) {
-			await generateClientJs(resolve(__dirname, config.outputFolder), Object.keys(tableInfo), 'surrealdb.js')
+			await generateClientJs(resolve(__dirname, config.outputFolder), Object.keys(tableInfo), 'surrealdb')
 		}
 	} catch (error) {
 		printSorry(error)


### PR DESCRIPTION
Hi @sebastianwessel !

I'm back after a bit more than a month out. It's good to see you have pushed some changes!

---

`v1.0.0-beta.19` has renamed its package name: https://github.com/surrealdb/surrealdb.js/releases/tag/v1.0.0-beta.19