### PR TITLE
fix table name in `recordId` calls

### DIFF
--- a/src/genSchema/generateTableSchema.ts
+++ b/src/genSchema/generateTableSchema.ts
@@ -109,7 +109,7 @@ export const ${tableName}CreateSchema = ${tableName}InputSchemaGen.merge(z.objec
 
 // payload schema for fetching a ${name} entity
 export const ${tableName}Schema = ${tableName}OutputSchemaGen.merge(z.object({
-  id: recordId("${table}"),
+  id: recordId("${name}"),
   // add your custom fields here, which are not part of SurrealDB table schema
   // they are not overwritten by the next run
       }))

--- a/src/genSchema/generateTableSchema.ts
+++ b/src/genSchema/generateTableSchema.ts
@@ -102,14 +102,14 @@ import { recordId } from "../../_generated/recordSchema.js";
 
 // payload schema for creating a new ${name} entity
 export const ${tableName}CreateSchema = ${tableName}InputSchemaGen.merge(z.object({
-  id: recordId("${tableName}").optional()
+  id: recordId("${table}").optional()
   // add your custom fields here, which are not part of SurrealDB table schema
   // they are not overwritten by the next run
       }))
 
 // payload schema for fetching a ${name} entity
 export const ${tableName}Schema = ${tableName}OutputSchemaGen.merge(z.object({
-  id: recordId("${tableName}"),
+  id: recordId("${table}"),
   // add your custom fields here, which are not part of SurrealDB table schema
   // they are not overwritten by the next run
       }))

--- a/src/genSchema/generateTableSchema.ts
+++ b/src/genSchema/generateTableSchema.ts
@@ -102,7 +102,7 @@ import { recordId } from "../../_generated/recordSchema.js";
 
 // payload schema for creating a new ${name} entity
 export const ${tableName}CreateSchema = ${tableName}InputSchemaGen.merge(z.object({
-  id: recordId("${table}").optional()
+  id: recordId("${name}").optional()
   // add your custom fields here, which are not part of SurrealDB table schema
   // they are not overwritten by the next run
       }))


### PR DESCRIPTION
I have tables in the `foo_bar` format.
When I try to use the generated types, I get ZodErrors for `RecordId` like this:
```haskell
ZodError: [{
  "code": "custom",
  "message": "RecordId must be of type 'fooBar'",
  "path": [
    "id"
  ]
}]
at Object.get error [as error] (file:///node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/index.mjs:587:31)
at _ZodObject.parse (file:///node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/index.mjs:692:22)
at getfooBarById (file:///surreal/models/my-project/client/fooBar/getfooBarById.ts:8:55)
```

I don't see why the `RecordId` would be created in the camelCase format if the table name is not camel case, unless I am missing something here.
It looks to me like a mistake introduced in #45.