### PR TITLE
fix invalid syntax in recordId schema

### DIFF
--- a/src/genSchema/ensureRecordSchema.ts
+++ b/src/genSchema/ensureRecordSchema.ts
@@ -67,7 +67,8 @@ export function recordId<Table extends string = string>(table?: Table) {
 				return new RecordId(val.tb, val.id) as RecordId<Table>
 			}
 			throw new Error('Invalid input for RecordId')
-		})`
+		});
+  }`
 
 	await mkdirp(rootPath)
 


### PR DESCRIPTION
The recordId schema is missing a closing curly bracket, which I added back in.