### PR TITLE
Handle enum definitions

### DIFF
--- a/src/genSchema/getDetailsFromDefinition.test.ts
+++ b/src/genSchema/getDetailsFromDefinition.test.ts
@@ -101,6 +101,130 @@ describe('getDetailsFromDefinition', () => {
 		})
 	})
 
+	describe('Union string literal types (enum-like)', () => {
+		const isInputSchema = true // Default for most of these, can be overridden
+
+		it('returns z.enum for basic union string literal type', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE "published" | "draft" | "archived";',
+				false, // isInputSchema = false for this output schema test
+			)
+			expect(result.name).toBe('status')
+			expect(result.type).toBe('"published" | "draft" | "archived"')
+			expect(result.zodString).toBe("z.enum(['published', 'draft', 'archived'])")
+		})
+
+		it('returns optional z.enum for option<union string literal type>', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE option<"published" | "draft">;',
+				false, // isInputSchema = false
+			)
+			expect(result.zodString).toBe("z.enum(['published', 'draft']).optional()")
+		})
+
+		it('returns optional z.enum for input schema with option<union string literal type>', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE option<"published" | "draft">;',
+				true, // isInputSchema = true
+			)
+			expect(result.zodString).toBe("z.enum(['published', 'draft']).optional()")
+		})
+
+		it('returns optional z.enum for input schema when union string literal type has a DEFAULT', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE "published" | "draft" DEFAULT "draft";',
+				isInputSchema, // true
+			)
+			expect(result.zodString).toBe("z.enum(['published', 'draft']).optional()")
+		})
+
+		it('returns required z.enum for output schema when union string literal type has a DEFAULT', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE "published" | "draft" DEFAULT "draft";',
+				false, // isInputSchema
+			)
+			expect(result.zodString).toBe("z.enum(['published', 'draft'])")
+		})
+
+		it('returns optional z.enum for input schema when option<union string literal type> has a DEFAULT', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE option<"published" | "draft"> DEFAULT "draft";',
+				isInputSchema, // true
+			)
+			expect(result.zodString).toBe("z.enum(['published', 'draft']).optional()")
+		})
+
+		it('returns required z.enum for output schema when option<union string literal type> has a DEFAULT', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD status ON post TYPE option<"published" | "draft"> DEFAULT "draft";',
+				false, // isInputSchema
+			)
+			expect(result.zodString).toBe("z.enum(['published', 'draft'])")
+		})
+
+		it('handles string literals with spaces', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD role ON user TYPE "project admin" | "content editor";',
+				false,
+			)
+			expect(result.zodString).toBe("z.enum(['project admin', 'content editor'])")
+		})
+
+		it('handles string literals with escaped quotes', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD message ON log TYPE "value with \\"quotes\\"" | "another value";',
+				false,
+			)
+			expect(result.zodString).toBe("z.enum(['value with \"quotes\"', 'another value'])")
+		})
+
+		it('handles string literals with other special characters if tokenizer passes them through', () => {
+			const result = getDetailsFromDefinition('DEFINE FIELD category ON item TYPE "tools/hardware" | "apparel";', false)
+			expect(result.zodString).toBe("z.enum(['tools/hardware', 'apparel'])")
+		})
+
+		it('should not conflict with regular string type if not a union literal', () => {
+			const result = getDetailsFromDefinition('DEFINE FIELD name ON "user" TYPE string;', false)
+			expect(result.zodString).toBe('z.string()')
+		})
+
+		it('should handle option<string> correctly and not misinterpret as enum', () => {
+			const result = getDetailsFromDefinition('DEFINE FIELD description ON "product" TYPE option<string>;', false)
+			expect(result.zodString).toBe('z.string().optional()')
+		})
+
+		it('returns z.enum for basic union string literal type with single quotes', () => {
+			const result = getDetailsFromDefinition(
+				"DEFINE FIELD status ON post TYPE 'published' | 'draft' | 'archived';",
+				false,
+			)
+			expect(result.name).toBe('status')
+			expect(result.type).toBe("'published' | 'draft' | 'archived'")
+			expect(result.zodString).toBe("z.enum(['published', 'draft', 'archived'])")
+		})
+
+		it('returns optional z.enum for option<union string literal type with single quotes>', () => {
+			const result = getDetailsFromDefinition("DEFINE FIELD status ON post TYPE option<'published' | 'draft'>;", false)
+			expect(result.zodString).toBe("z.enum(['published', 'draft']).optional()")
+		})
+
+		it('handles single-quoted string literals with escaped single quotes', () => {
+			const result = getDetailsFromDefinition(
+				"DEFINE FIELD message ON log TYPE 'value with \\'quotes\\'' | 'another value';",
+				false,
+			)
+			expect(result.zodString).toBe("z.enum(['value with \\'quotes\\'', 'another value'])")
+		})
+
+		it('handles mixed quotes if the tokenizer allows (though SurrealDB likely expects consistency per literal)', () => {
+			const result = getDetailsFromDefinition(
+				'DEFINE FIELD mixed ON test TYPE "double_quoted" | \'single_quoted\';',
+				false,
+			)
+			expect(result.zodString).toBe("z.enum(['double_quoted', 'single_quoted'])")
+		})
+	})
+
 	describe('output schema', () => {
 		const isInputSchema = false
 		it('returns optional string for optional string without default', () => {

--- a/src/genSchema/getDetailsFromDefinition.ts
+++ b/src/genSchema/getDetailsFromDefinition.ts
@@ -1,10 +1,9 @@
 import { type SchemaType, handleAssertions } from './handleAssertions.js'
 import { type TokenizedDefinition, tokenize } from './tokenize.js'
 
-const typeRegex = /(?:option<)?(\w+)(?:<(\w+)(?:<(\w+)>)?>)?/i
-const recordRegex = /record(?:<(\w+)>)?/i
-
 export type FieldDetail = TokenizedDefinition & { zodString: string; skip: boolean }
+
+const typeRegex = /(?:option<)?(\w+)(?:<(\w+)(?:<(\w+)>)?>)?/i
 
 const getArrayType = (tokens: TokenizedDefinition, isInputSchema: boolean): string => {
 	const match = tokens.type?.match(typeRegex)
@@ -15,13 +14,11 @@ const getArrayType = (tokens: TokenizedDefinition, isInputSchema: boolean): stri
 			const recordType = match[3]
 			return recordType ? `recordId('${recordType}').array()` : 'recordId().array()'
 		}
-		const innerType = getZodTypeFromQLType(
-			{
-				...tokens,
-				type: match[2],
-			},
-			isInputSchema,
-		)
+		const innerTypeDefinition: TokenizedDefinition = {
+			...tokens,
+			type: match[2],
+		}
+		const innerType = getZodTypeFromQLType(innerTypeDefinition, isInputSchema)
 		return `z.array(${innerType})`
 	}
 	return 'z.array(z.unknown())'
@@ -36,7 +33,6 @@ const makeOptional = (schema: string, tokens: TokenizedDefinition, isInputSchema
 	) {
 		return `${schema}.optional()`
 	}
-
 	return schema
 }
 
@@ -62,33 +58,113 @@ const getSchemaForType = (type: string, tokens: TokenizedDefinition, isInputSche
 		case 'object':
 			return subSchema ?? 'z.object({})'
 		case 'record': {
+			const recordRegex = /record(?:<(\w+)>)?/i
 			const recordMatch = tokens.type?.match(recordRegex)
 			const recordType = recordMatch?.[1]
 			return recordType ? `recordId('${recordType}')` : 'recordId()'
 		}
+		case 'duration':
+			return 'z.string()'
+		case 'uuid':
+			return 'z.string().uuid()'
+		case 'any':
+			return 'z.any()'
+		case 'point':
+		case 'line':
+		case 'polygon':
+		case 'multipoint':
+		case 'multiline':
+		case 'multipolygon':
+		case 'collection':
+		case 'geometrycollection':
+		case 'geometry':
+			return 'z.object({}).passthrough()'
 		default:
 			return 'z.unknown()'
 	}
 }
 
-export const getZodTypeFromQLType = (tokens: TokenizedDefinition, isInputSchema: boolean, subSchema?: string) => {
-	const match = tokens.type?.match(typeRegex)
+export const getZodTypeFromQLType = (
+	tokens: TokenizedDefinition,
+	isInputSchema: boolean,
+	subSchema?: string,
+): string => {
+	let typeStringToProcess = tokens.type
+	let isExplicitlyOptional = false
+
+	if (!typeStringToProcess && tokens.flexible) {
+		// Handle FLEXIBLE fields with no explicit TYPE
+		typeStringToProcess = 'any'
+	}
+
+	if (typeStringToProcess?.toLowerCase().startsWith('option<') && typeStringToProcess.endsWith('>')) {
+		isExplicitlyOptional = true
+		typeStringToProcess = typeStringToProcess.substring('option<'.length, typeStringToProcess.length - 1)
+	}
+
+	if (typeStringToProcess) {
+		const valueExtractionRegex = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'/g
+		const valueMatchesForValidation = Array.from(typeStringToProcess.matchAll(valueExtractionRegex))
+		let isValidStructure = false
+
+		if (valueMatchesForValidation.length > 0) {
+			let reconstructedForValidation = ''
+			valueMatchesForValidation.forEach((match, index) => {
+				reconstructedForValidation += match[0]
+				if (index < valueMatchesForValidation.length - 1) {
+					reconstructedForValidation += ' | '
+				}
+			})
+			const normalizedOriginal = typeStringToProcess.replace(/\s*\|\s*/g, ' | ')
+			const normalizedReconstructed = reconstructedForValidation.replace(/\s*\|\s*/g, ' | ')
+			if (normalizedOriginal === normalizedReconstructed) {
+				isValidStructure = true
+			}
+		}
+
+		if (isValidStructure) {
+			const matches = Array.from(typeStringToProcess.matchAll(valueExtractionRegex))
+
+			if (matches && matches.length > 0) {
+				const enumValues = matches.map(match => {
+					const doubleQuotedContent = match[1]
+					const singleQuotedContent = match[2]
+					const content = doubleQuotedContent !== undefined ? doubleQuotedContent : (singleQuotedContent ?? '')
+
+					return content.replace(/\\"/g, '"').replace(/\\'/g, "'").replace(/\\\\/g, '\\')
+				})
+
+				let schema = `z.enum([${enumValues.map(v => `'${v.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`).join(', ')}])`
+				schema = makeOptional(schema, tokens, isInputSchema)
+				return schema
+			}
+		}
+	}
+
+	const typeRegex = /(?:option<)?([\w]+)(?:<([\w<>.'"]+)>)?/i // Adjusted to better handle nested generics
+	const match = typeStringToProcess?.match(typeRegex)
 
 	if (match?.[1]) {
-		const type = match[1].toLowerCase() as SchemaType
-		let schema = getSchemaForType(type, tokens, isInputSchema, subSchema)
+		const typeKeyword = match[1].toLowerCase() as SchemaType
+		const currentLevelTokens: TokenizedDefinition = { ...tokens, type: typeStringToProcess }
+		let schema = getSchemaForType(typeKeyword, currentLevelTokens, isInputSchema, subSchema)
 
 		if (tokens.assert) {
-			schema = handleAssertions(schema, tokens.assert, type)
+			schema = handleAssertions(schema, tokens.assert, typeKeyword)
 		}
 
-		if (type === 'object') {
+		if (typeKeyword === 'object') {
 			schema = makeFlexible(schema, !!tokens.flexible)
 		}
-		schema = makeOptional(schema, tokens, isInputSchema)
 
+		schema = makeOptional(schema, tokens, isInputSchema)
 		return schema
 	}
+
+	if (isExplicitlyOptional) {
+		return 'z.unknown().optional()'
+	}
+
 	return 'z.unknown()'
 }
 
@@ -98,7 +174,6 @@ export const shouldFieldBeSkipped = (tokens: TokenizedDefinition, isInputSchema:
 
 export const getDetailsFromDefinition = (definition: string, isInputSchema: boolean): FieldDetail => {
 	const tokens = tokenize(definition)
-
 	return {
 		...tokens,
 		zodString: getZodTypeFromQLType(tokens, isInputSchema),


### PR DESCRIPTION
Correctly handle enum definitions such as `DEFINE FIELD status ON test TYPE "draft" | "active"` to return a zod.enum rather than unknown. Also added object defualts for geometry types and a uuid handler.