### PR TITLE
Handle unquoted enums and union types

### DIFF
--- a/src/genSchema/getDetailsFromDefinition.test.ts
+++ b/src/genSchema/getDetailsFromDefinition.test.ts
@@ -216,14 +216,46 @@ describe('getDetailsFromDefinition', () => {
 			expect(result.zodString).toBe("z.enum(['value with \\'quotes\\'', 'another value'])")
 		})
 
-		it('handles mixed quotes if the tokenizer allows (though SurrealDB likely expects consistency per literal)', () => {
-			const result = getDetailsFromDefinition(
-				'DEFINE FIELD mixed ON test TYPE "double_quoted" | \'single_quoted\';',
-				false,
-			)
-			expect(result.zodString).toBe("z.enum(['double_quoted', 'single_quoted'])")
-		})
-	})
+                it('handles mixed quotes if the tokenizer allows (though SurrealDB likely expects consistency per literal)', () => {
+                        const result = getDetailsFromDefinition(
+                                'DEFINE FIELD mixed ON test TYPE "double_quoted" | \'single_quoted\';',
+                                false,
+                        )
+                        expect(result.zodString).toBe("z.enum(['double_quoted', 'single_quoted'])")
+                })
+
+                it('handles unquoted enum values', () => {
+                        const result = getDetailsFromDefinition(
+                                'DEFINE FIELD status ON post TYPE published | draft | archived;',
+                                false,
+                        )
+                        expect(result.zodString).toBe("z.enum(['published', 'draft', 'archived'])")
+                })
+
+                it('handles option<unquoted enum values>', () => {
+                        const result = getDetailsFromDefinition(
+                                'DEFINE FIELD status ON post TYPE option<published | draft>;',
+                                false,
+                        )
+                        expect(result.zodString).toBe("z.enum(['published', 'draft']).optional()")
+                })
+
+                it('handles union of types', () => {
+                        const result = getDetailsFromDefinition(
+                                'DEFINE FIELD uid ON account TYPE uuid | int;',
+                                false,
+                        )
+                        expect(result.zodString).toBe('z.union([z.string().uuid(), z.number()])')
+                })
+
+                it('handles option<union of types>', () => {
+                        const result = getDetailsFromDefinition(
+                                'DEFINE FIELD uid ON account TYPE option<uuid | int>;',
+                                false,
+                        )
+                        expect(result.zodString).toBe('z.union([z.string().uuid(), z.number()]).optional()')
+                })
+        })
 
 	describe('output schema', () => {
 		const isInputSchema = false


### PR DESCRIPTION
## Summary
- detect SurrealQL union types and map them to `z.union`
- support enums defined without quotes
- test unquoted enum parsing and union type handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68546930af348328954fc5199af92488