### PR TITLE
Fix multiline enum parsing

### DIFF
--- a/src/genSchema/handleAssertions.test.ts
+++ b/src/genSchema/handleAssertions.test.ts
@@ -41,10 +41,15 @@ describe('handleAssertions', () => {
 			expect(handleAssertions('z.string()', 'string::len($value) = 8', 'string')).toBe('z.string().length(8)')
 		})
 
-		it('handles IN and INSIDE assertions', () => {
-			expect(handleAssertions('z.string()', "IN ['a', 'b', 'c']", 'string')).toBe("z.enum(['a', 'b', 'c'])")
-			expect(handleAssertions('z.string()', "INSIDE ['x', 'y', 'z']", 'string')).toBe("z.enum(['x', 'y', 'z'])")
-		})
+                it('handles IN and INSIDE assertions', () => {
+                        expect(handleAssertions('z.string()', "IN ['a', 'b', 'c']", 'string')).toBe("z.enum(['a', 'b', 'c'])")
+                        expect(handleAssertions('z.string()', "INSIDE ['x', 'y', 'z']", 'string')).toBe("z.enum(['x', 'y', 'z'])")
+                })
+
+                it('handles multiline IN assertions', () => {
+                        const multiline = "$value IN [\n'a', 'b', 'c' ]"
+                        expect(handleAssertions('z.string()', multiline, 'string')).toBe("z.enum(['a', 'b', 'c'])")
+                })
 
 		it('handles NOT IN and NOTINSIDE assertions', () => {
 			const expected = `

--- a/src/genSchema/handleAssertions.ts
+++ b/src/genSchema/handleAssertions.ts
@@ -81,24 +81,28 @@ const handleStringAssertions = (schema: string, condition: string): string => {
 		}
 	}
 
-	if (condition.includes('NOT IN') || condition.includes('NOTINSIDE')) {
-		const match = condition.match(/(NOT IN|NOTINSIDE)\s*(\[.*?])/)
+       if (condition.includes('NOT IN') || condition.includes('NOTINSIDE')) {
+               const match = condition.match(/(NOT IN|NOTINSIDE)\s*(\[[\s\S]*?])/)
 		if (match?.[2]) {
 			const values = match[2].trim()
 			return `${schema}.refine((val) => !${values}.includes(val), {
             message: "String must not be one of ${values}",
         })`
 		}
-	} else if (condition.includes('INSIDE')) {
-		const match = condition.match(/INSIDE\s*(\[.*?])/)
-		if (match?.[1]) {
-			return `z.enum(${match[1].trim()})`
-		}
-	} else if (condition.includes('IN')) {
-		const match = condition.match(/\bIN\s*(\[.*?])/)
-		if (match?.[1]) {
-			return `z.enum(${match[1].trim()})`
-		}
+       } else if (condition.includes('INSIDE')) {
+               const match = condition.match(/INSIDE\s*(\[[\s\S]*?])/)
+               if (match?.[1]) {
+                       let values = match[1].replace(/\s+/g, ' ').trim()
+                       values = values.replace(/\[\s+/, '[').replace(/\s+\]/, ']')
+                       return `z.enum(${values})`
+               }
+       } else if (condition.includes('IN')) {
+               const match = condition.match(/\bIN\s*(\[[\s\S]*?])/)
+               if (match?.[1]) {
+                       let values = match[1].replace(/\s+/g, ' ').trim()
+                       values = values.replace(/\[\s+/, '[').replace(/\s+\]/, ']')
+                       return `z.enum(${values})`
+               }
 	}
 
 	const multiWordRegex = /^array::len\(string::words\(\$value\)\)\s*>\s*1$/

--- a/src/genSchema/tokenize.ts
+++ b/src/genSchema/tokenize.ts
@@ -3,7 +3,7 @@ const FIELD_CLAUSES = ['TYPE', 'REFERENCE', 'DEFAULT', 'READONLY', 'VALUE', 'ASS
 const PATTERNS = {
 	CLAUSE_BOUNDARY: `\\s+(?:${FIELD_CLAUSES.join('|')})\\s+|$`,
 	CAPTURE_UNTIL_NEXT_CLAUSE: (keyword: string) =>
-		new RegExp(`${keyword}\\s+(.*?)(?=${`\\s+(?:${FIELD_CLAUSES.join('|')})\\s+|$`})`, 'im'),
+		new RegExp(`${keyword}\\s+(.*?)(?=${`\\s+(?:${FIELD_CLAUSES.join('|')})\\s+|$`})`, 'is'),
 	FOR_CLAUSE: /FOR\s+(select|create|update|delete)\s+([^FOR]*?)(?=\s+FOR\s+|$)/gim,
 	DEFINE_FIELD: /DEFINE FIELD(?: IF NOT EXISTS)?\s+(.*?)\s+ON(?: TABLE)?\s+([\w.:`\-\[\]*]+)/im,
 } as const


### PR DESCRIPTION
## Summary
- handle multiline enum values in assertions
- ensure regex for field clauses works across lines
- test multiline enum parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685472b3c918832883455c67f71e2983